### PR TITLE
Add dark mode option

### DIFF
--- a/GameBrowser/EditBrowser.xaml
+++ b/GameBrowser/EditBrowser.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="500" d:DesignWidth="600">
-    <Grid TextOptions.TextFormattingMode="Display">
+    <Grid x:Name="root" TextOptions.TextFormattingMode="Display">
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
             <ColumnDefinition Width="10"/>

--- a/GameBrowser/EditBrowser.xaml.vb
+++ b/GameBrowser/EditBrowser.xaml.vb
@@ -62,4 +62,15 @@ Public Class EditBrowser
     Private Sub lblRecent_Initialized(sender As Object, e As EventArgs) Handles lblRecent.Initialized
         lblRecent.Content = T("LauncherRecent")
     End Sub
+
+    Public Sub ApplyDarkTheme(isDark As Boolean)
+        Dim darkBg As New Windows.Media.SolidColorBrush(Windows.Media.Color.FromRgb(45, 45, 48))
+        Dim darkFg As Windows.Media.Brush = Windows.Media.Brushes.White
+        Dim lightBg As New Windows.Media.SolidColorBrush(Windows.Media.Color.FromRgb(255, 255, 255))
+        Dim lightFg As Windows.Media.Brush = Windows.Media.Brushes.Black
+        Dim bg As Windows.Media.Brush = If(isDark, darkBg, lightBg)
+        Dim fg As Windows.Media.Brush = If(isDark, darkFg, lightFg)
+        root.Background = bg
+        root.Foreground = fg
+    End Sub
 End Class

--- a/GameBrowser/GameDescription.xaml
+++ b/GameBrowser/GameDescription.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <Grid Background="GhostWhite" TextOptions.TextFormattingMode="Display">
+    <Grid x:Name="root" TextOptions.TextFormattingMode="Display">
         <Border BorderThickness="1">
             <Border.BorderBrush>
                 <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">

--- a/GameBrowser/GameDescription.xaml.vb
+++ b/GameBrowser/GameDescription.xaml.vb
@@ -246,4 +246,15 @@ Public Class GameDescription
         expander.Header = T("LauncherReviewsAndComments")
     End Sub
 
+    Public Sub ApplyDarkTheme(isDark As Boolean)
+        Dim darkBg As New Windows.Media.SolidColorBrush(Windows.Media.Color.FromRgb(45, 45, 48))
+        Dim darkFg As Windows.Media.Brush = Windows.Media.Brushes.White
+        Dim lightBg As New Windows.Media.SolidColorBrush(Windows.Media.Color.FromRgb(255, 255, 255))
+        Dim lightFg As Windows.Media.Brush = Windows.Media.Brushes.Black
+        Dim bg As Windows.Media.Brush = If(isDark, darkBg, lightBg)
+        Dim fg As Windows.Media.Brush = If(isDark, darkFg, lightFg)
+        root.Background = bg
+        root.Foreground = fg
+    End Sub
+
 End Class

--- a/GameBrowser/Launcher.xaml
+++ b/GameBrowser/Launcher.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="400" d:DesignWidth="500">
-    <Grid TextOptions.TextFormattingMode="Display">
+    <Grid x:Name="root" TextOptions.TextFormattingMode="Display">
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>

--- a/GameBrowser/Launcher.xaml.vb
+++ b/GameBrowser/Launcher.xaml.vb
@@ -23,6 +23,26 @@ Public Class Launcher
         AddHandler ctlEditBrowser.Tutorial, AddressOf ctlEditBrowser_Tutorial
     End Sub
 
+    Public Sub ApplyDarkTheme(isDark As Boolean)
+        Dim darkBg As New System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(45, 45, 48))
+        Dim darkFg As System.Windows.Media.Brush = System.Windows.Media.Brushes.White
+        Dim lightBg As New System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(243, 243, 249))
+        Dim lightFg As System.Windows.Media.Brush = System.Windows.Media.Brushes.Black
+        Dim bg As System.Windows.Media.Brush = If(isDark, darkBg, lightBg)
+        Dim fg As System.Windows.Media.Brush = If(isDark, darkFg, lightFg)
+
+        Me.Background = bg
+        root.Background = bg
+        ctlTabs.Background = bg
+        ctlTabs.Foreground = fg
+        For Each item As System.Windows.Controls.TabItem In ctlTabs.Items
+            item.Background = bg
+            item.Foreground = fg
+        Next
+        ctlPlayBrowser.ApplyDarkTheme(isDark)
+        ctlEditBrowser.ApplyDarkTheme(isDark)
+    End Sub
+
     Public Sub AddToRecent(filename As String, name As String)
         ctlPlayBrowser.AddToRecent(filename, name)
     End Sub

--- a/GameBrowser/PlayBrowser.xaml
+++ b/GameBrowser/PlayBrowser.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="500">
-    <Grid TextOptions.TextFormattingMode="Display">
+    <Grid x:Name="root" TextOptions.TextFormattingMode="Display">
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
             <ColumnDefinition Width="10"/>

--- a/GameBrowser/PlayBrowser.xaml.vb
+++ b/GameBrowser/PlayBrowser.xaml.vb
@@ -97,6 +97,18 @@ Public Class PlayBrowser
         ctlOnlineGameList.UnselectCurrentItem()
     End Sub
 
+    Public Sub ApplyDarkTheme(isDark As Boolean)
+        Dim darkBg As New Windows.Media.SolidColorBrush(Windows.Media.Color.FromRgb(45, 45, 48))
+        Dim darkFg As Windows.Media.Brush = Windows.Media.Brushes.White
+        Dim lightBg As New Windows.Media.SolidColorBrush(Windows.Media.Color.FromRgb(255, 255, 255))
+        Dim lightFg As Windows.Media.Brush = Windows.Media.Brushes.Black
+        Dim bg As Windows.Media.Brush = If(isDark, darkBg, lightBg)
+        Dim fg As Windows.Media.Brush = If(isDark, darkFg, lightFg)
+        root.Background = bg
+        root.Foreground = fg
+        ctlGameDescription.ApplyDarkTheme(isDark)
+    End Sub
+
     Public Property DownloadFolder As String
         Get
             Return ctlOnlineGameList.DownloadFolder

--- a/Quest/Main.vb
+++ b/Quest/Main.vb
@@ -45,6 +45,8 @@ Public Class Main
         AddHandler ctlLauncher.EditGame, AddressOf ctlLauncher_EditGame
         AddHandler ctlLauncher.LaunchGame, AddressOf ctlLauncher_LaunchGame
         AddHandler ctlLauncher.Tutorial, AddressOf ctlLauncher_Tutorial
+
+        ApplyTheme(Options.Instance.GetBooleanValue(OptionNames.DarkMode))
     End Sub
 
     Private Sub CurrentDispatcher_UnhandledException(sender As Object, e As System.Windows.Threading.DispatcherUnhandledExceptionEventArgs)
@@ -465,7 +467,33 @@ Public Class Main
                 ctlPlayer.PlaySounds = Options.Instance.GetBooleanValue(OptionNames.PlaySounds)
             Case OptionNames.UseSAPI
                 ctlPlayer.UseSAPI = Options.Instance.GetBooleanValue(OptionNames.UseSAPI)
+            Case OptionNames.DarkMode
+                ApplyTheme(Options.Instance.GetBooleanValue(OptionNames.DarkMode))
         End Select
+    End Sub
+
+    Private Sub ApplyTheme(dark As Boolean)
+        Dim bg As Color
+        Dim fg As Color
+        If dark Then
+            bg = Color.FromArgb(45, 45, 48)
+            fg = Color.White
+        Else
+            bg = Color.GhostWhite
+            fg = SystemColors.ControlText
+        End If
+        ApplyThemeToControl(Me, bg, fg)
+        If ctlLauncher IsNot Nothing Then
+            ctlLauncher.ApplyDarkTheme(dark)
+        End If
+    End Sub
+
+    Private Sub ApplyThemeToControl(ctrl As Control, bg As Color, fg As Color)
+        ctrl.BackColor = bg
+        ctrl.ForeColor = fg
+        For Each child As Control In ctrl.Controls
+            ApplyThemeToControl(child, bg, fg)
+        Next
     End Sub
 
 End Class

--- a/Quest/Options.vb
+++ b/Quest/Options.vb
@@ -12,6 +12,7 @@ Public Enum OptionNames
     GamesFolder
     PlaySounds
     UseSAPI
+    DarkMode
 End Enum
 
 Public Class Options
@@ -39,7 +40,8 @@ Public Class Options
                         "Quest Games",
                         "Downloaded Games")},
         {OptionNames.PlaySounds, True.ToString()},
-        {OptionNames.UseSAPI, False.ToString()}
+        {OptionNames.UseSAPI, False.ToString()},
+        {OptionNames.DarkMode, False.ToString()}
     }
 
     Public Event OptionChanged(optionName As OptionNames)

--- a/Quest/OptionsDialog.vb
+++ b/Quest/OptionsDialog.vb
@@ -5,6 +5,7 @@ Public Class OptionsDialog
     Private fontFamily As String
     Private fontSize As Single
     Private fontStyle As FontStyle
+    Private chkDarkMode As CheckBox
 
     Public Sub New()
         ' This call is required by the designer.
@@ -22,6 +23,13 @@ Public Class OptionsDialog
         txtGamesFolder.Text = Options.Instance.GetStringValue(OptionNames.GamesFolder)
         chkPlaySounds.Checked = Options.Instance.GetBooleanValue(OptionNames.PlaySounds)
         chkUseSAPI.Checked = Options.Instance.GetBooleanValue(OptionNames.UseSAPI)
+        chkDarkMode = New CheckBox()
+        chkDarkMode.AutoSize = True
+        chkDarkMode.Name = "chkDarkMode"
+        chkDarkMode.Text = "Use dark mode"
+        chkDarkMode.Location = New Point(chkUseSAPI.Left, chkUseSAPI.Bottom + 6)
+        TabPage1.Controls.Add(chkDarkMode)
+        chkDarkMode.Checked = Options.Instance.GetBooleanValue(OptionNames.DarkMode)
         UpdateSampleText()
     End Sub
 
@@ -65,6 +73,7 @@ Public Class OptionsDialog
         Options.Instance.SetStringValue(OptionNames.GamesFolder, txtGamesFolder.Text)
         Options.Instance.SetBooleanValue(OptionNames.PlaySounds, chkPlaySounds.Checked)
         Options.Instance.SetBooleanValue(OptionNames.UseSAPI, chkUseSAPI.Checked)
+        Options.Instance.SetBooleanValue(OptionNames.DarkMode, chkDarkMode.Checked)
         Me.Hide()
     End Sub
 


### PR DESCRIPTION
## Summary
- add `DarkMode` to the options list
- provide a Dark Mode checkbox in Options dialog
- apply theme colours in `Main` and across WPF controls
- wire up GameBrowser controls to switch colours

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887560a28e8832296b7291304fa8fbc